### PR TITLE
feat(auth): endpoints de register y login

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,5 @@
+**/__pycache__/
 /venv
 /.ruff_cache
+/.env
+/.cartero

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,15 +1,17 @@
-from dotenv import load_dotenv
 from flask import Flask, jsonify
 
-load_dotenv()
+from src.routes import blueprints
 
 app = Flask(__name__)
+
+for bp in blueprints:
+    app.register_blueprint(bp)
 
 
 @app.route('/')
 def index():
-    return jsonify({'status': 'ok'})
+    return jsonify({'status': True})
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(debug=True)  # hypercorn app:app --reload

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,9 @@
 flask
+flask[async]
 supabase
+hypercorn
 python-dotenv
+pydantic
+pydantic[email]
+bcrypt
+dataclasses-json

--- a/backend/shell.nix
+++ b/backend/shell.nix
@@ -6,6 +6,7 @@ pkgs.mkShell {
   buildInputs = with pkgs; [
     ruff
     isort
+    pyright
     python312
     python312Packages.python-lsp-server
     python312Packages.python-lsp-ruff

--- a/backend/src/classes/__init__.py
+++ b/backend/src/classes/__init__.py
@@ -1,0 +1,21 @@
+from flask import jsonify
+
+
+class Response:
+    @staticmethod
+    def success(message=None, data=None, status_code=200):
+        payload = {'status': True}
+        if message:
+            payload['message'] = message
+        if data:
+            payload['data'] = data
+        return jsonify(payload), status_code
+
+    @staticmethod
+    def error(message=None, errors=None, status_code=400):
+        payload = {'status': False}
+        if message:
+            payload['message'] = message
+        if errors:
+            payload['errors'] = errors
+        return jsonify(payload), status_code

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -1,0 +1,10 @@
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class Config:
+    SUPABASE_URL = os.getenv('SUPABASE_URL')
+    SUPABASE_KEY = os.getenv('SUPABASE_KEY')

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -8,3 +8,4 @@ load_dotenv()
 class Config:
     SUPABASE_URL = os.getenv('SUPABASE_URL')
     SUPABASE_KEY = os.getenv('SUPABASE_KEY')
+    SECRET_KEY = os.getenv('SECRET_KEY')

--- a/backend/src/decorators/__init__.py
+++ b/backend/src/decorators/__init__.py
@@ -1,0 +1,38 @@
+from functools import wraps
+
+import jwt
+from flask import request
+
+from ..classes import Response as res
+from ..config import Config
+
+
+def requires_roles(allowed_roles: list[str]):
+    def decorator(f):
+        @wraps(f)
+        def wrapped(*args, **kwargs):
+            token = request.cookies.get('auth_token')
+            if not token:
+                return res.error(
+                    'Authentication token is missing', status_code=401
+                )
+            try:
+                payload = jwt.decode(
+                    token, Config.SECRET_KEY, algorithms=['HS256']
+                )
+            except jwt.ExpiredSignatureError:
+                return res.error('Token expired', status_code=401)
+            except jwt.InvalidTokenError:
+                return res.error('Invalid token', status_code=401)
+
+            user_role = payload.get('role')
+            if user_role not in allowed_roles:
+                return res.error(
+                    'Forbidden: insufficient privileges', status_code=403
+                )
+
+            return f(*args, **kwargs)
+
+        return wrapped
+
+    return decorator

--- a/backend/src/routes/__init__.py
+++ b/backend/src/routes/__init__.py
@@ -1,5 +1,3 @@
 from .auth import auth_bp
 
-blueprints = [auth_bp]
-
-__all__ = blueprints
+__all__ = blueprints = [auth_bp]

--- a/backend/src/routes/__init__.py
+++ b/backend/src/routes/__init__.py
@@ -1,0 +1,5 @@
+from .auth import auth_bp
+
+blueprints = [auth_bp]
+
+__all__ = blueprints

--- a/backend/src/routes/auth.py
+++ b/backend/src/routes/auth.py
@@ -1,12 +1,15 @@
 import asyncio
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import bcrypt
+import jwt
 from dataclasses_json import LetterCase, dataclass_json
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, make_response, request
 from pydantic import ValidationError
 
+from ..classes import Response as res
+from ..config import Config
 from ..schemas import UserLoginPayload, UserRegisterPayload, UserRole
 from ..supabase_client import get_connection
 
@@ -19,7 +22,7 @@ class UserData:
     email: str
     name: str
     password_hash: str
-    role: UserRole = UserRole.OPERATOR
+    role: str = UserRole.OPERATOR.to_string()
     created_at: str = datetime.utcnow().isoformat()
 
 
@@ -31,6 +34,7 @@ class AuthService:
         )
         return hashed.decode()
 
+    @staticmethod
     async def verify_password(password: str, password_hash: str) -> bool:
         return await asyncio.to_thread(
             bcrypt.checkpw, password.encode(), password_hash.encode()
@@ -40,15 +44,18 @@ class AuthService:
     async def fetch_user(email: str) -> UserData | None:
         conn = await get_connection()
         response = (
-            await conn.table('users').select('*').eq('email', email).execute()
+            await conn.table('users').select('*').eq('email', email).execute
         )
 
         if response.data:
-            return UserData.from_dict(response[0])
+            return UserData.from_dict(response.data[0])
 
     @staticmethod
     async def create_user(
-        name: str, email: str, password: str, role: UserRole = UserRole.OPERATOR
+        name: str,
+        email: str,
+        password: str,
+        role: str = UserRole.OPERATOR.to_string(),
     ) -> bool:
         password_hash = await AuthService.hash_password(password)
         user = UserData(
@@ -61,6 +68,18 @@ class AuthService:
 
         return True
 
+    @staticmethod
+    def create_token(user: UserData):
+        return jwt.encode(
+            payload={
+                'email': user.email,
+                'role': user.role,
+                'exp': datetime.utcnow() + timedelta(days=30),
+            },
+            key=Config.SECRET_KEY,
+            algorithm='HS256',
+        ).decode('utf-8')
+
 
 @auth_bp.route('/register', methods=['POST'])
 async def register():
@@ -68,20 +87,16 @@ async def register():
         raw_data = request.get_json()
         data = UserRegisterPayload(**raw_data)
     except ValidationError as e:
-        return jsonify({'status': False, 'errors': e.errors()}), 400
+        return res.error(errors=e.errors())
     except Exception:
-        return jsonify({'status': False, 'message': 'Invalid JSON'}), 400
+        return res.error('Invalid JSON')
 
-    if not await AuthService.fetch_user(data.email):
-        return jsonify(
-            {'status': False, 'message': 'Email already registered'}
-        ), 400
+    if await AuthService.fetch_user(data.email):
+        return res.error('Email already registered')
 
     await AuthService.create_user(data.name, data.email, data.password)
 
-    return jsonify(
-        {'status': True, 'message': f'User {data.name} registered successfully'}
-    )
+    return res.success(message=f'User {data.name} registered successfully')
 
 
 @auth_bp.route('/login', methods=['POST'])
@@ -90,20 +105,27 @@ async def login():
         raw_data = request.get_json()
         data = UserLoginPayload(**raw_data)
     except ValidationError as e:
-        return jsonify({'status': False, 'errors': e.errors()}), 400
+        return res.error(errors=e.errors())
     except Exception:
-        return jsonify({'status': False, 'message': 'Invalid JSON'}), 400
+        return res.error('Invalid JSON')
 
-    db_user = await AuthService.fetch_user(data.email)
+    if not (user := await AuthService.fetch_user(data.email)):
+        return res.error('Email not registered')
 
-    if not db_user:
-        return jsonify(
-            {'status': False, 'message': 'Email not registered'}
-        ), 400
+    if not await AuthService.verify_password(data.password, user.password_hash):
+        return res.error('Invalid password')
 
-    # Todo:
-    # Verify hash
-    # Create token
-    # Return token
+    token = AuthService.create_token(user)
 
-    return jsonify({'status': True})
+    response = make_response(res.success('Logged in')[0])
+    response.set_cookie(
+        'auth_token',
+        token,
+        httponly=True,
+        secure=True,
+        samesite='Lax',
+        max_age=2592000,  # 30 días
+        path='/',
+    )
+
+    return response

--- a/backend/src/routes/auth.py
+++ b/backend/src/routes/auth.py
@@ -1,0 +1,109 @@
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime
+
+import bcrypt
+from dataclasses_json import LetterCase, dataclass_json
+from flask import Blueprint, jsonify, request
+from pydantic import ValidationError
+
+from ..schemas import UserLoginPayload, UserRegisterPayload, UserRole
+from ..supabase_client import get_connection
+
+auth_bp = Blueprint('auth', __name__)
+
+
+@dataclass_json(letter_case=LetterCase.SNAKE)
+@dataclass
+class UserData:
+    email: str
+    name: str
+    password_hash: str
+    role: UserRole = UserRole.OPERATOR
+    created_at: str = datetime.utcnow().isoformat()
+
+
+class AuthService:
+    @staticmethod
+    async def hash_password(password: str) -> str:
+        hashed = await asyncio.to_thread(
+            bcrypt.hashpw, password.encode(), bcrypt.gensalt()
+        )
+        return hashed.decode()
+
+    async def verify_password(password: str, password_hash: str) -> bool:
+        return await asyncio.to_thread(
+            bcrypt.checkpw, password.encode(), password_hash.encode()
+        )
+
+    @staticmethod
+    async def fetch_user(email: str) -> UserData | None:
+        conn = await get_connection()
+        response = (
+            await conn.table('users').select('*').eq('email', email).execute()
+        )
+
+        if response.data:
+            return UserData.from_dict(response[0])
+
+    @staticmethod
+    async def create_user(
+        name: str, email: str, password: str, role: UserRole = UserRole.OPERATOR
+    ) -> bool:
+        password_hash = await AuthService.hash_password(password)
+        user = UserData(
+            name=name, email=email, password_hash=password_hash, role=role
+        )
+
+        conn = await get_connection()
+
+        await conn.table('users').insert(user.to_dict()).execute()
+
+        return True
+
+
+@auth_bp.route('/register', methods=['POST'])
+async def register():
+    try:
+        raw_data = request.get_json()
+        data = UserRegisterPayload(**raw_data)
+    except ValidationError as e:
+        return jsonify({'status': False, 'errors': e.errors()}), 400
+    except Exception:
+        return jsonify({'status': False, 'message': 'Invalid JSON'}), 400
+
+    if not await AuthService.fetch_user(data.email):
+        return jsonify(
+            {'status': False, 'message': 'Email already registered'}
+        ), 400
+
+    await AuthService.create_user(data.name, data.email, data.password)
+
+    return jsonify(
+        {'status': True, 'message': f'User {data.name} registered successfully'}
+    )
+
+
+@auth_bp.route('/login', methods=['POST'])
+async def login():
+    try:
+        raw_data = request.get_json()
+        data = UserLoginPayload(**raw_data)
+    except ValidationError as e:
+        return jsonify({'status': False, 'errors': e.errors()}), 400
+    except Exception:
+        return jsonify({'status': False, 'message': 'Invalid JSON'}), 400
+
+    db_user = await AuthService.fetch_user(data.email)
+
+    if not db_user:
+        return jsonify(
+            {'status': False, 'message': 'Email not registered'}
+        ), 400
+
+    # Todo:
+    # Verify hash
+    # Create token
+    # Return token
+
+    return jsonify({'status': True})

--- a/backend/src/schemas/__init__.py
+++ b/backend/src/schemas/__init__.py
@@ -1,0 +1,1 @@
+from .auth import UserLoginPayload, UserRegisterPayload, UserRole

--- a/backend/src/schemas/auth.py
+++ b/backend/src/schemas/auth.py
@@ -1,0 +1,22 @@
+from enum import Enum
+from typing import TypedDict
+
+from pydantic import BaseModel, EmailStr
+
+
+class UserRegisterPayload(BaseModel):
+    name: str
+    email: EmailStr
+    password: str
+
+
+class UserLoginPayload(TypedDict):
+    email: str
+    password: str
+
+
+class UserRole(Enum):
+    ADMIN = 'ADMIN'
+    MANAGER = 'MANAGER'
+    AUDITOR = 'AUDITOR'
+    OPERATOR = 'OPERATOR'

--- a/backend/src/schemas/auth.py
+++ b/backend/src/schemas/auth.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import TypedDict
 
 from pydantic import BaseModel, EmailStr
 
@@ -10,13 +9,20 @@ class UserRegisterPayload(BaseModel):
     password: str
 
 
-class UserLoginPayload(TypedDict):
-    email: str
+class UserLoginPayload(BaseModel):
+    email: EmailStr
     password: str
 
 
 class UserRole(Enum):
-    ADMIN = 'ADMIN'
-    MANAGER = 'MANAGER'
-    AUDITOR = 'AUDITOR'
-    OPERATOR = 'OPERATOR'
+    OPERATOR = 1
+    AUDITOR = 2
+    MANAGER = 3
+    ADMIN = 4
+
+    def to_string(self) -> str:
+        return self.name
+
+    @classmethod
+    def from_string(cls, value: str) -> 'UserRole':
+        return cls[value.upper()]

--- a/backend/src/supabase_client.py
+++ b/backend/src/supabase_client.py
@@ -8,11 +8,9 @@ _instance = None
 async def get_connection() -> AsyncClient:
     global _instance
 
-    if _instance is not None:
-        return _instance
-
-    _instance = await create_async_client(
-        Config.SUPABASE_URL, Config.SUPABASE_KEY
-    )
+    if _instance is None:
+        _instance = await create_async_client(
+            Config.SUPABASE_URL, Config.SUPABASE_KEY
+        )
 
     return _instance

--- a/backend/src/supabase_client.py
+++ b/backend/src/supabase_client.py
@@ -1,0 +1,18 @@
+from supabase import AsyncClient, create_async_client
+
+from .config import Config
+
+_instance = None
+
+
+async def get_connection() -> AsyncClient:
+    global _instance
+
+    if _instance is not None:
+        return _instance
+
+    _instance = await create_async_client(
+        Config.SUPABASE_URL, Config.SUPABASE_KEY
+    )
+
+    return _instance


### PR DESCRIPTION
Se implementa la base del backend con Flask y Supabase, incluyendo los endpoints de autenticación para registro e inicio de sesión de usuarios.

### Cambios principales

* Endpoint `POST /register`: crea un nuevo usuario en Supabase.
* Endpoint `POST /login`: valida credenciales y retorna JWT en cookie.
* Esquemas de validación con Pydantic (`UserRegisterPayload`, `UserLoginPayload`).
* Encriptado de contraseñas con `bcrypt`.